### PR TITLE
fix: patch relative includes in otterbrix 1.0.0a12-rc-1

### DIFF
--- a/recipes/otterbrix/1.x/conandata.yml
+++ b/recipes/otterbrix/1.x/conandata.yml
@@ -7,3 +7,6 @@ patches:
     - patch_file: "patches/fix-flex-bison-output-dir.patch"
       patch_description: "Create output directory for flex/bison generated files"
       patch_type: "bugfix"
+    - patch_file: "patches/fix-catalog-compute-includes.patch"
+      patch_description: "Fix relative includes in namespace_storage.hpp to use absolute component paths"
+      patch_type: "bugfix"

--- a/recipes/otterbrix/1.x/patches/fix-catalog-compute-includes.patch
+++ b/recipes/otterbrix/1.x/patches/fix-catalog-compute-includes.patch
@@ -1,0 +1,12 @@
+--- a/components/catalog/namespace_storage.hpp
++++ b/components/catalog/namespace_storage.hpp
+@@ -1,7 +1,7 @@
+ #pragma once
+
+-#include "compute/compute_kernel.hpp"
+-#include "compute/function.hpp"
++#include <components/compute/compute_kernel.hpp>
++#include <components/compute/function.hpp>
+ #include "computed_schema.hpp"
+ #include "table_id.hpp"
+ #include "table_metadata.hpp"


### PR DESCRIPTION
## Summary
- Adds patch for `namespace_storage.hpp` in otterbrix `1.0.0a12-rc-1`
- Fixes relative includes `"compute/compute_kernel.hpp"` and `"compute/function.hpp"` that fail to resolve in packaged headers
- Changed to absolute component paths: `<components/compute/compute_kernel.hpp>`

## Context
otterbrix build uses `include_directories(${CMAKE_SOURCE_DIR})` so relative includes work during build, but in the Conan package the include root is different, causing compilation failures in consumers (otterstax CI).