### PR TITLE
fix: add otterbrix::session link to table component

### DIFF
--- a/recipes/otterbrix/1.x/conandata.yml
+++ b/recipes/otterbrix/1.x/conandata.yml
@@ -10,3 +10,6 @@ patches:
     - patch_file: "patches/fix-catalog-compute-includes.patch"
       patch_description: "Fix relative includes in namespace_storage.hpp to use absolute component paths"
       patch_type: "bugfix"
+    - patch_file: "patches/fix-table-session-link.patch"
+      patch_description: "Fix missing otterbrix::session link in table component (transaction_manager uses session_id_t::data())"
+      patch_type: "bugfix"

--- a/recipes/otterbrix/1.x/patches/fix-table-session-link.patch
+++ b/recipes/otterbrix/1.x/patches/fix-table-session-link.patch
@@ -1,0 +1,10 @@
+--- a/components/table/CMakeLists.txt
++++ b/components/table/CMakeLists.txt
+@@ -35,6 +35,7 @@ target_link_libraries(
+         otterbrix_${PROJECT_NAME} PRIVATE
+         otterbrix::expressions
+         otterbrix::file
++        otterbrix::session
+         otterbrix::types
+         otterbrix::vector
+

--- a/recipes/otterbrix/1.x/patches/fix-table-session-link.patch
+++ b/recipes/otterbrix/1.x/patches/fix-table-session-link.patch
@@ -1,6 +1,6 @@
 --- a/components/table/CMakeLists.txt
 +++ b/components/table/CMakeLists.txt
-@@ -35,6 +35,7 @@ target_link_libraries(
+@@ -50,6 +50,7 @@ target_link_libraries(
          otterbrix_${PROJECT_NAME} PRIVATE
          otterbrix::expressions
          otterbrix::file


### PR DESCRIPTION
## Summary

- `transaction_manager.cpp` in otterbrix 1.0.0a12-rc-1 calls `session_id_t::data()`, but the table component's `CMakeLists.txt` does not link against `otterbrix::session`
- This leaves an undefined reference in `libotterbrix_table.so` which causes a linker error when building executables that depend on it
- Patch adds `otterbrix::session` to `target_link_libraries` of the table component

## Test plan

- [ ] Build otterbrix 1.0.0a12-rc-1 via Conan and verify `libotterbrix_table.so` links cleanly
- [ ] Verify otterstax CI passes (otterstax/otterstax#12)