### PR TITLE
add actor-zeta 1.2.0

### DIFF
--- a/recipes/actor-zeta/all/conandata.yml
+++ b/recipes/actor-zeta/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "1.2.0":
+    url: "https://github.com/duckstax/actor-zeta/archive/1.2.0.tar.gz"
+    sha256: "b8ee4a85fa8999e4e6e16a5d2f19ce510772755d04c5d4c92b3f687b6113d02d"
+
   "1.1.1":
     url: "https://github.com/duckstax/actor-zeta/archive/1.1.1.tar.gz"
     sha256: "758376faa49d1c87fd60c6b216221af9c51ffca86a1e9ef6667a59af16262348"

--- a/recipes/actor-zeta/config.yml
+++ b/recipes/actor-zeta/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.2.0":
+    folder: "all"
   "1.1.1":
     folder: "all"
   "1.1.0":


### PR DESCRIPTION
## Summary
- Adds `actor-zeta/1.2.0` to the recipes index and source list
- Pulls archive from `https://github.com/duckstax/actor-zeta/archive/1.2.0.tar.gz` (sha256 `b8ee4a85…3d02d`, verified locally)
- No conanfile.py changes needed — existing `validate()` already enforces C++20 for `>= 1.1.0`, and the archive layout is identical to 1.1.x

## Test plan
- [ ] CI: `yaml-lint`, `validate-recipes`, `python-lint` pass (verified locally with the same configs)
- [ ] CI: `Build (ubuntu-24.04)` and `Build (macos-15)` succeed for `actor-zeta/1.2.0`
- [ ] After merge: confirm package gets uploaded to the otterbrix conan remote