### PR TITLE
feat(otterbrix): add version 1.0.0a13-rc-3

### DIFF
--- a/recipes/otterbrix/1.x/conandata.yml
+++ b/recipes/otterbrix/1.x/conandata.yml
@@ -1,4 +1,7 @@
 sources:
+  "1.0.0a13-rc-3":
+    url: "https://github.com/otterbrix/otterbrix/archive/refs/tags/1.0.0a13-rc-3.tar.gz"
+    sha256: "bd1e3b5a88310c00ecdd9f347151e9ab05f6651f1a7180d61ce6470588f234fc"
   "1.0.0a13-rc-2":
     url: "https://github.com/otterbrix/otterbrix/archive/refs/tags/1.0.0a13-rc-2.tar.gz"
     sha256: "d958bee4d0a734dbfd56a5917ec8396fddc56208fe6c202611e7cbc2806e387c"
@@ -9,6 +12,10 @@ sources:
     url: "https://github.com/otterbrix/otterbrix/archive/refs/tags/1.0.0a12-rc-3.tar.gz"
     sha256: "d3074d84fa2a83a799ccc43c8c034dc33812d32ab887280bf93f1af6e49ba2a4"
 patches:
+  "1.0.0a13-rc-3":
+    - patch_file: "patches/fix-flex-bison-output-dir.patch"
+      patch_description: "Create output directory for flex/bison generated files"
+      patch_type: "bugfix"
   "1.0.0a13-rc-2":
     - patch_file: "patches/fix-flex-bison-output-dir.patch"
       patch_description: "Create output directory for flex/bison generated files"

--- a/recipes/otterbrix/config.yml
+++ b/recipes/otterbrix/config.yml
@@ -1,4 +1,6 @@
 versions:
+  "1.0.0a13-rc-3":
+    folder: "1.x"
   "1.0.0a13-rc-2":
     folder: "1.x"
   "1.0.0a13-rc-1":


### PR DESCRIPTION
Adds otterbrix `1.0.0a13-rc-3` to the recipe.

- `config.yml`: new version entry pointing at the `1.x` folder
- `conandata.yml`: source URL and sha256 (computed from the actual tarball)
- Patches: only `fix-flex-bison-output-dir.patch` is carried over, same as rc-2; verified with a dry-run that it still applies cleanly to the rc-3 sources

`conan export recipes/otterbrix/1.x --version=1.0.0a13-rc-3` succeeds locally.
