### PR TITLE
feat(otterbrix): support only 1.0.0b2-rc-1

### DIFF
--- a/recipes/otterbrix/1.x/conandata.yml
+++ b/recipes/otterbrix/1.x/conandata.yml
@@ -1,9 +1,9 @@
 sources:
-  "1.0.0b1":
-    url: "https://github.com/otterbrix/otterbrix/archive/refs/tags/1.0.0b1.tar.gz"
-    sha256: "79f280a5d40f9f02a1c0e1d60272a245b59a45bdaaf163e694668b51eaf9edc2"
+  "1.0.0b2-rc-1":
+    url: "https://github.com/otterbrix/otterbrix/archive/refs/tags/1.0.0b2-rc-1.tar.gz"
+    sha256: "a10fd2dd1ee863118563e77bdd265a86c128bcf2e4c3e0e7ecaa7dd58edf66f1"
 patches:
-  "1.0.0b1":
+  "1.0.0b2-rc-1":
     - patch_file: "patches/fix-flex-bison-output-dir.patch"
       patch_description: "Create output directory for flex/bison generated files"
       patch_type: "bugfix"

--- a/recipes/otterbrix/1.x/conanfile.py
+++ b/recipes/otterbrix/1.x/conanfile.py
@@ -37,14 +37,13 @@ class Otterbrix(ConanFile):
         check_min_cppstd(self, 20)
 
     def requirements(self):
-        self.requires("boost/1.88.0", force=True)
+        self.requires("boost/1.88.0")
         self.requires("fmt/11.1.3")
         self.requires("spdlog/1.15.1")
         if self.options.build_python:
             self.requires("pybind11/2.13.6")
-        self.requires("msgpack-cxx/4.1.1")
-        self.requires("catch2/2.13.7")
-        self.requires("abseil/20230802.1")
+        self.requires("catch2/3.15.2")
+        self.requires("abseil/20260107.1")
         self.requires("benchmark/1.6.1")
         self.requires("zlib/1.3.1")
         self.requires("bzip2/1.0.8")
@@ -114,7 +113,7 @@ class Otterbrix(ConanFile):
 
         self.cpp_info.requires = [
             "boost::boost", "abseil::abseil", "actor-zeta::actor-zeta",
-            "msgpack-cxx::msgpack-cxx", "fast_float::fast_float",
+            "fast_float::fast_float",
             "fmt::fmt", "spdlog::spdlog", "zlib::zlib", "bzip2::bzip2",
             "catch2::catch2", "benchmark::benchmark",
         ]

--- a/recipes/otterbrix/1.x/test_package/CMakeLists.txt
+++ b/recipes/otterbrix/1.x/test_package/CMakeLists.txt
@@ -3,8 +3,8 @@ project(test_package LANGUAGES CXX)
 
 find_package(absl REQUIRED)
 find_package(otterbrix REQUIRED)
-find_package(Catch2 2.13.7 REQUIRED)
-find_package(Boost 1.87.0 REQUIRED)
+find_package(Catch2 3 REQUIRED)
+find_package(Boost 1.88.0 REQUIRED)
 find_package(Threads)
 
 add_executable(test_package test.cpp)
@@ -17,5 +17,4 @@ target_link_libraries(test_package
     Catch2::Catch2
     absl::flat_hash_map
     absl::node_hash_map
-    msgpackc-cxx
 )

--- a/recipes/otterbrix/1.x/test_package/conanfile.py
+++ b/recipes/otterbrix/1.x/test_package/conanfile.py
@@ -11,12 +11,11 @@ class OtterbrixTestConan(ConanFile):
 
     def requirements(self):
         self.requires(self.tested_reference_str)
-        self.requires("boost/1.88.0", force=True)
+        self.requires("boost/1.88.0")
         self.requires("fmt/11.1.3")
         self.requires("spdlog/1.15.1")
-        self.requires("msgpack-cxx/4.1.1")
-        self.requires("catch2/2.13.7")
-        self.requires("abseil/20230802.1")
+        self.requires("catch2/3.15.2")
+        self.requires("abseil/20260107.1")
         self.requires("benchmark/1.6.1")
         self.requires("zlib/1.3.1")
         self.requires("bzip2/1.0.8")

--- a/recipes/otterbrix/config.yml
+++ b/recipes/otterbrix/config.yml
@@ -1,3 +1,3 @@
 versions:
-  "1.0.0b1":
+  "1.0.0b2-rc-1":
     folder: "1.x"


### PR DESCRIPTION
## Что

Заменяет версию `otterbrix` `1.0.0b1` на `1.0.0b2-rc-1` (последний upstream-тег `otterbrix/otterbrix`) и приводит зависимости рецепта в соответствие с upstream.

## Изменения зависимостей

- **catch2 `2.13.7` → `3.15.2`** — upstream `1.0.0b2-rc-1` перешёл на Catch2 v3 (`find_package(Catch2 3 REQUIRED)`); прежний `2.13.7` не соберётся. Upstream-точной `3.15.1` нет ни в ConanCenter, ни на otterbrix-remote — доступна `3.15.2`, и она удовлетворяет `find_package(Catch2 3)`.
- **abseil `20230802.1` → `20260107.1`** — как в upstream (есть в ConanCenter).
- **Удалён неиспользуемый `msgpack-cxx`** — в исходниках otterbrix `1.0.0b2-rc-1` ноль упоминаний msgpack (ни CMake, ни `#include`); upstream его тоже не объявляет. Вместе с ним убран **`boost … force=True`**, который был нужен только из-за транзитивного `boost/[>=1.53 <2]` от msgpack (больше никто в графе boost не тянет).

## Файлы

- `config.yml`, `1.x/conandata.yml` — версия + url + новый sha256 (`a10fd2dd…`), патч `fix-flex-bison-output-dir.patch` сохранён.
- `1.x/conanfile.py` — catch2/abseil, drop boost-force и msgpack (в `requirements()` и `cpp_info.requires`).
- `1.x/test_package/{conanfile.py,CMakeLists.txt}` — зеркалит зависимости; `find_package(Catch2 3)`, `Boost 1.88.0`, убран таргет `msgpackc-cxx`.

## Проверка

`conan create recipes/otterbrix/1.x --version=1.0.0b2-rc-1 -o "actor-zeta/*:cxx_standard=20" -s build_type=Release --build=missing` на macOS (arm64, apple-clang, C++20):
- тарбол скачан по sha256, патч flex/bison применён;
- catch2 v3 собран, otterbrix скомпилирован целиком;
- **test_package слинкован (без msgpack) и запущен успешно** (`Otterbrix test package running!`).

> Примечание: локально на macOS для генерации парсера нужен современный Bison (`export PATH="/opt/homebrew/opt/bison/bin:$PATH"`); системный bison 2.3 не понимает грамматику otterbrix. CI (ubuntu-24.04 / macos-15) это не затрагивает.